### PR TITLE
Bugfix: Custom initial solution for Flight class

### DIFF
--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -274,6 +274,9 @@ class Rocket:
         self.thrustToWeight.setInputs('Time (s)')
         self.thrustToWeight.setOutputs('Thrust/Weight')
 
+        # Evaluate static margin (even though no aerodynamic surfaces are present yet)
+        self.evaluateStaticMargin()
+
         return None
 
     def evaluateReducedMass(self):
@@ -374,6 +377,7 @@ class Rocket:
         self.staticMargin = (self.centerOfMass - self.cpPosition) / (2 * self.radius)
         self.staticMargin.setInputs("Time (s)")
         self.staticMargin.setOutputs("Static Margin (c)")
+        self.staticMargin.setDiscrete(lower=0, upper=self.motor.burnOutTime, samples=200)
 
         # Return self
         return self


### PR DESCRIPTION
# Description

Since many versions ago (could not map exactly which), the `initialSolution` argument of the **Flight class** stopped working.

The problem occurred since given an initial solution, the rocket may be already out of rail since the first simulation step. This triggered the _out of rail event_ which tried to find out when the rocket left the rail by performing root finding. When no solutions can be found, an exception is raised.

## Type of change

- [x] Bug fix
- [x] This change does not requires a documentation update