### PR TITLE
ENH: Environment Analysis - Time Zones

### DIFF
--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -64,7 +64,7 @@ class EnvironmentAnalysis:
         self.surfaceDataFile = surfaceDataFile
         self.pressureLevelDataFile = pressureLevelDataFile
         self.prefered_timezone = timezone
-        
+
         # Manage timezones
         self.__find_prefered_timezone()
         self.__localize_input_dates()
@@ -284,7 +284,7 @@ class EnvironmentAnalysis:
         if self.prefered_timezone is None:
             # Use local timezone based on lat lon pair
             tf = TimezoneFinder()
-            self.prefered_timezone =  pytz.timezone(
+            self.prefered_timezone = pytz.timezone(
                 tf.timezone_at(lng=self.longitude, lat=self.latitude)
             )
         elif isinstance(self.prefered_timezone, str):


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, every datetime used and printed/plotted by the `EnvironmentAnalysis` class is in UTC.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now, the user can specify which timezone he prefers to use. This can be specially useful to display results in a timezone which is easier to understand.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No