### PR TITLE
ENH: Refactor Rocket.addFins to avoid breaking changes

### DIFF
--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -345,18 +345,19 @@
          "source": [
             "NoseCone = Calisto.addNose(length=0.55829, kind=\"vonKarman\", distanceToCM=0.71971)\n",
             "\n",
-            "FinSet = Calisto.addFins(type=\"trapezoid\",\n",
+            "FinSet = Calisto.addTrapezoidalFins(\n",
             "                         n=4,\n",
-            "                         finParameters={\"span\": 0.100, \n",
-            "                                        \"rootChord\": 0.120,\n",
-            "                                        \"tipChord\": 0.040},\n",
+            "                         rootChord=0.120,\n",
+            "                         tipChord=0.040,\n",
+            "                         span=0.100,\n",
             "                         distanceToCM=-1.04956,\n",
-            "                         radius=0,\n",
             "                         cantAngle=0,\n",
+            "                         radius=None,\n",
             "                         airfoil=None,)\n",
+            "\n",
             "Tail = Calisto.addTail(\n",
             "    topRadius=0.0635, bottomRadius=0.0435, length=0.060, distanceToCM=-1.194656\n",
-            ")"
+            ")   "
          ]
       },
       {
@@ -1445,7 +1446,7 @@
    "metadata": {
       "hide_input": false,
       "kernelspec": {
-         "display_name": "Python 3.9.7 64-bit",
+         "display_name": "Python 3.10.5 64-bit",
          "language": "python",
          "name": "python3"
       },
@@ -1459,11 +1460,11 @@
          "name": "python",
          "nbconvert_exporter": "python",
          "pygments_lexer": "ipython3",
-         "version": "3.9.7"
+         "version": "3.10.5"
       },
       "vscode": {
          "interpreter": {
-            "hash": "9a10bcc997267b1a89bac5e776345fae8434c0a748fbfd6e7071b7bad5bf06c4"
+            "hash": "26de051ba29f2982a8de78e945f0abaf191376122a1563185a90213a26c5da77"
          }
       }
    },

--- a/docs/notebooks/getting_started_colab.ipynb
+++ b/docs/notebooks/getting_started_colab.ipynb
@@ -360,19 +360,19 @@
    "source": [
     "NoseCone = Calisto.addNose(length=0.55829, kind=\"vonKarman\", distanceToCM=0.71971)\n",
     "\n",
-    "FinSet = Calisto.addFins(type=\"trapezoid\",\n",
+    "FinSet = Calisto.addTrapezoidalFins(\n",
     "                         n=4,\n",
-    "                         finParameters={\"span\": 0.100, \n",
-    "                                        \"rootChord\": 0.120,\n",
-    "                                        \"tipChord\": 0.040},\n",
+    "                         rootChord=0.120,\n",
+    "                         tipChord=0.040,\n",
+    "                         span=0.100,\n",
     "                         distanceToCM=-1.04956,\n",
-    "                         radius=0,\n",
     "                         cantAngle=0,\n",
+    "                         radius=None,\n",
     "                         airfoil=None,)\n",
     "\n",
     "Tail = Calisto.addTail(\n",
     "    topRadius=0.0635, bottomRadius=0.0435, length=0.060, distanceToCM=-1.194656\n",
-    ")"
+    ")   "
    ]
   },
   {
@@ -973,7 +973,7 @@
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.5 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -987,7 +987,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.10.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "26de051ba29f2982a8de78e945f0abaf191376122a1563185a90213a26c5da77"
+   }
   }
  },
  "nbformat": 4,

--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -4,6 +4,7 @@ __author__ = "Giovani Hidalgo Ceotto, Franz Masatoshi Yuri, Mateus Stano Junquei
 __copyright__ = "Copyright 20XX, RocketPy Team"
 __license__ = "MIT"
 
+import warnings
 from inspect import getsourcelines
 from collections import namedtuple
 
@@ -460,32 +461,43 @@ class Rocket:
         # Return self
         return self.aerodynamicSurfaces[-1]
 
-    def addFins(
+    def addFins(self,*args, **kwargs):
+        """See Rocket.addTrapezoidalFins for documentation.
+        This method is set to be deprecated in version 1.0.0 and fully removed
+        by version 2.0.0. Use Rocket.addTrapezoidalFins instead. It keeps the
+        same arguments and signature."""
+        warnings.warn(
+            "This method is set to be deprecated in version 1.0.0 and fully"
+            "removed by version 2.0.0. Use Rocket.addTrapezoidalFins instead",
+            PendingDeprecationWarning
+        )
+        self.addTrapezoidalFins(*args, **kwargs)
+
+    def addTrapezoidalFins(
         self,
-        type,
         n,
-        finParameters,
+        rootChord,
+        tipChord,
+        span,
         distanceToCM,
-        radius=0,
+        radius=None,
         cantAngle=0,
-        airfoil=None,
+        airfoil=None
     ):
-        """Create a fin set, storing its parameters as part of the
+        """Create a trapezoidal fin set, storing its parameters as part of the
         aerodynamicSurfaces list. Its parameters are the axial position
         along the rocket and its derivative of the coefficient of lift
         in respect to angle of attack.
         Parameters
         ----------
-        type: string
-            Type of fin selected to the rocket. Must be either "trapezoid"
-            or "elliptical".
-        finParameters: dictionary
-            Dictionary containing geometric parameters about the fin selected.
-            For trapezoid fins: must have "span", "rootChord" and "tipChord"
-            key words.
-            For elliptical fins: must have "span" and "rootChord" key words.
         n : int
             Number of fins, from 2 to infinity.
+        span : int, float
+            Fin span in meters.
+        rootChord : int, float
+            Fin root chord in meters.
+        tipChord : int, float
+            Fin tip chord in meters.
         distanceToCM : int, float
             Fin set position relative to rocket unloaded center of
             mass, considering positive direction from center of mass to
@@ -523,262 +535,6 @@ class Rocket:
         self : Rocket
             Object of the Rocket class.
         """
-        # Checking the dictionary
-        if "rootChord" not in finParameters.keys():
-            raise Exception("rootChord dictionary key is missing from finParameters")
-        if "span" not in finParameters.keys():
-            raise Exception("span dictionary key is missing from finParameters")
-
-        if type == "trapezoid":
-            if "tipChord" not in finParameters.keys():
-                raise Exception("tipChord dictionary key is missing from finParameters")
-
-        # Retrieves abstract parameters
-        Cr = finParameters["rootChord"]
-        s = finParameters["span"]
-        radius = self.radius if radius == 0 else radius
-        cantAngleRad = np.radians(cantAngle)
-        d = 2 * radius
-
-        # Type verification
-        if type == "trapezoid":
-
-            # Retrieve parameters for calculations
-            Ct = finParameters["tipChord"]
-            Yr = Cr + Ct
-
-            Af = Yr * s / 2  # fin area
-            gamac = np.arctan((Cr - Ct) / (2 * s))  # mid chord angle
-            Yma = (
-                (s / 3) * (Cr + 2 * Ct) / Yr
-            )  # span wise position of fin's mean aerodynamic chord
-
-            rollGeometricalConstant = (
-                (Cr + 3 * Ct) * s**3
-                + 4 * (Cr + 2 * Ct) * radius * s**2
-                + 6 * (Cr + Ct) * s * radius**2
-            ) / 12
-
-            # Calculate cp position relative to cm
-            if distanceToCM < 0:
-                cpz = distanceToCM - (
-                    ((Cr - Ct) / 3) * ((Cr + 2 * Ct) / (Cr + Ct))
-                    + (1 / 6) * (Cr + Ct - Cr * Ct / (Cr + Ct))
-                )
-            else:
-                cpz = distanceToCM + (
-                    ((Cr - Ct) / 3) * ((Cr + 2 * Ct) / (Cr + Ct))
-                    + (1 / 6) * (Cr + Ct - Cr * Ct / (Cr + Ct))
-                )
-
-        elif type == "elliptical":
-
-            # Retrieve parameters for calculations
-            Af = (np.pi * Cr / 2 * s) / 2
-            gamac = 0
-            Yma = s / (3 * np.pi) * np.sqrt(9 * np.pi**2 - 16)
-            rollGeometricalConstant = (
-                Cr
-                * s
-                * (3 * np.pi * s**2 + 32 * radius * s + 12 * np.pi * radius**2)
-                / 48
-            )
-
-            # Calculate cp position relative to cm
-            if distanceToCM < 0:
-                cpz = distanceToCM - (0.288 * Cr)
-            else:
-                cpz = distanceToCM + (0.288 * Cr)
-
-        else:
-            raise Exception("Invalid fin shape")
-
-        # Retrieves abstract parameters
-        Aref = np.pi * radius**2
-        AR = 2 * s**2 / Af
-        rollParameters = [0, 0, 0]
-
-        # Fin–body interference correction parameters
-        tau = (s + radius) / radius
-        liftInterferenceFactor = 1 + 1 / tau
-        if type == "trapezoid":
-            λ = Ct / Cr
-            rollDampingInterferenceFactor = 1 + (
-                ((tau - λ) / (tau)) - ((1 - λ) / (tau - 1)) * np.log(tau)
-            ) / (
-                ((tau + 1) * (tau - λ)) / (2)
-                - ((1 - λ) * (tau**3 - 1)) / (3 * (tau - 1))
-            )
-        else:  # type == "elliptical"
-            rollDampingInterferenceFactor = 1 + (
-                (radius**2)
-                * (
-                    2
-                    * (radius**2)
-                    * np.sqrt(s**2 - radius**2)
-                    * np.log(
-                        (2 * s * np.sqrt(s**2 - radius**2) + 2 * s**2) / radius
-                    )
-                    - 2 * (radius**2) * np.sqrt(s**2 - radius**2) * np.log(2 * s)
-                    + 2 * s**3
-                    - np.pi * radius * s**2
-                    - 2 * (radius**2) * s
-                    + np.pi * radius**3
-                )
-            ) / (2 * (s**2) * (s / 3 + np.pi * radius / 4) * (s**2 - radius**2))
-
-        rollForcingInterferenceFactor = (1 / np.pi**2) * (
-            (np.pi**2 / 4) * ((tau + 1) ** 2 / tau**2)
-            + ((np.pi * (tau**2 + 1) ** 2) / (tau**2 * (tau - 1) ** 2))
-            * np.arcsin((tau**2 - 1) / (tau**2 + 1))
-            - (2 * np.pi * (tau + 1)) / (tau * (tau - 1))
-            + ((tau**2 + 1) ** 2)
-            / (tau**2 * (tau - 1) ** 2)
-            * (np.arcsin((tau**2 - 1) / (tau**2 + 1))) ** 2
-            - (4 * (tau + 1))
-            / (tau * (tau - 1))
-            * np.arcsin((tau**2 - 1) / (tau**2 + 1))
-            + (8 / (tau - 1) ** 2) * np.log((tau**2 + 1) / (2 * tau))
-        )
-
-        # Auxiliary functions
-        # Defines beta parameter
-        def beta(mach):
-            """Defines a parameter that is commonly used in aerodynamic
-            equations. It is commonly used in the Prandtl factor which
-            corrects subsonic force coefficients for compressible flow.
-
-            Parameters
-            ----------
-            mach : int, float
-                Number of mach.
-
-            Returns
-            -------
-            beta : int, float
-                Value that characterizes flow speed based on the mach number.
-            """
-
-            if mach < 0.8:
-                return np.sqrt(1 - mach**2)
-            elif mach < 1.1:
-                return np.sqrt(1 - 0.8**2)
-            else:
-                return np.sqrt(mach**2 - 1)
-
-        # Defines number of fins correction
-        def finNumCorrection(n):
-            """Calculates a corrector factor for the lift coefficient of multiple fins.
-            The specifics  values are documented at:
-            Niskanen, S. (2013). “OpenRocket technical documentation”. In: Development
-            of an Open Source model rocket simulation software.
-
-            Parameters
-            ----------
-            n : int
-                Number of fins.
-
-            Returns
-            -------
-            Corrector factor : int
-                Factor that accounts for the number of fins.
-            """
-            correctorFactor = [2.37, 2.74, 2.99, 3.24]
-            if n >= 5 and n <= 8:
-                return correctorFactor[n - 5]
-            else:
-                return n / 2
-
-        # Calculate cp position relative to cm
-        cpz = distanceToCM + np.sign(distanceToCM) * (
-            ((Cr - Ct) / 3) * ((Cr + 2 * Ct) / (Cr + Ct))
-            + (1 / 6) * (Cr + Ct - Cr * Ct / (Cr + Ct))
-        )
-
-        if not airfoil:
-            # Defines clalpha2D as 2*pi for planar fins
-            clalpha2D = Function(lambda mach: 2 * np.pi / beta(mach))
-        else:
-            # Defines clalpha2D as the derivative of the
-            # lift coefficient curve for a specific airfoil
-            airfoilCl = Function(
-                airfoil[0],
-                interpolation="linear",
-            )
-
-            # Differentiating at x = 0 to get cl_alpha
-            clalpha2D_Mach0 = airfoilCl.differentiate(x=1e-3, dx=1e-3)
-
-            # Convert to radians if needed
-            if airfoil[1] == "degrees":
-                clalpha2D_Mach0 *= 180 / np.pi
-
-            # Correcting for compressible flow
-            clalpha2D = Function(lambda mach: clalpha2D_Mach0 / beta(mach))
-        # Diederich's Planform Correlation Parameter
-        FD = 2 * np.pi * AR / (clalpha2D * np.cos(gamac))
-
-        # Lift coefficient derivative for a single fin
-        clalphaSingleFin = Function(
-            lambda mach: (clalpha2D(mach) * FD(mach) * (Af / Aref) * np.cos(gamac))
-            / (2 + FD(mach) * np.sqrt(1 + (2 / FD(mach)) ** 2))
-        )
-
-        # Lift coefficient derivative for a number of n fins corrected for Fin-Body interference
-        clalphaMultipleFins = (
-            liftInterferenceFactor * finNumCorrection(n) * clalphaSingleFin
-        )  # Function of mach number
-
-        # Calculates clalpha * alpha
-        cl = Function(
-            lambda alpha, mach: alpha * clalphaMultipleFins(mach),
-            ["Alpha (rad)", "Mach"],
-            "Cl",
-        )
-
-        # Parameters for Roll Moment.
-        # Documented at: https://github.com/Projeto-Jupiter/RocketPy/blob/develop/docs/technical/aerodynamics/Roll_Equations.pdf
-        clfDelta = (
-            rollForcingInterferenceFactor * n * (Yma + radius) * clalphaSingleFin / d
-        )  # Function of mach number
-        cldOmega = (
-            2
-            * rollDampingInterferenceFactor
-            * n
-            * clalphaSingleFin
-            * np.cos(cantAngleRad)
-            * rollGeometricalConstant
-            / (Aref * d**2)
-        )
-        # Function of mach number
-        rollParameters = [clfDelta, cldOmega, cantAngleRad]
-
-        # Store values
-        fin = {
-            "cp": (0, 0, cpz),
-            "cl": cl,
-            "roll parameters": rollParameters,
-            "name": "Fins",
-        }
-        self.aerodynamicSurfaces.append(fin)
-
-        # Refresh static margin calculation
-        self.evaluateStaticMargin()
-
-        # Return self
-        return self.aerodynamicSurfaces[-1]
-
-    def addTrapezoidalFins(
-        self,
-        n,
-        rootChord,
-        tipChord,
-        span,
-        distanceToCM,
-        radius=None,
-        cantAngle=0,
-        airfoil=None
-    ):
         # Retrieves and convert basic geometrical parameters
         Cr, Ct = rootChord, tipChord
         s = span
@@ -788,10 +544,10 @@ class Rocket:
         # Compute auxiliary geometrical parameters
         d = 2 * radius
         Aref = np.pi * radius**2
-        AR = 2 * s**2 / Af
         Yr = Cr + Ct
-        Af = Yr * s / 2  # Fin Area
-        gamac = np.arctan((Cr - Ct) / (2 * s))  # Mid Chord Angle
+        Af = Yr * s / 2 # Fin area
+        AR = 2 * s**2 / Af # Fin aspect ratio
+        gamac = np.arctan((Cr - Ct) / (2 * s))  # Mid chord angle
         Yma = (s / 3) * (Cr + 2 * Ct) / Yr # Span wise coord of mean aero chord
         rollGeometricalConstant = (
             (Cr + 3 * Ct) * s**3
@@ -947,6 +703,244 @@ class Rocket:
         self.evaluateStaticMargin()
 
         # Return the created aerodynamic surface
+        return self.aerodynamicSurfaces[-1]
+    
+    def addEllipticalFins(
+        self,
+        n,
+        rootChord,
+        span,
+        distanceToCM,
+        radius=0,
+        cantAngle=0,
+        airfoil=None,
+    ):
+        """Create an elliptical fin set, storing its parameters as part of the
+        aerodynamicSurfaces list. Its parameters are the axial position
+        along the rocket and its derivative of the coefficient of lift
+        in respect to angle of attack.
+        Parameters
+        ----------
+        type: string
+            Type of fin selected to the rocket. Must be either "trapezoid"
+            or "elliptical".
+        span : int, float
+            Fin span in meters.
+        rootChord : int, float
+            Fin root chord in meters.
+        n : int
+            Number of fins, from 2 to infinity.
+        distanceToCM : int, float
+            Fin set position relative to rocket unloaded center of
+            mass, considering positive direction from center of mass to
+            nose cone. Consider the center point belonging to the top
+            of the fins to calculate distance.
+        radius : int, float, optional
+            Reference radius to calculate lift coefficient. If 0, which
+            is default, use rocket radius. Otherwise, enter the radius
+            of the rocket in the section of the fins, as this impacts
+            its lift coefficient.
+        cantAngle : int, float, optional
+            Fins cant angle with respect to the rocket centerline. Must
+            be given in degrees.
+        airfoil : tuple, optional
+            Default is null, in which case fins will be treated as flat plates.
+            Otherwise, if tuple, fins will be considered as airfoils. The
+            tuple's first item specifies the airfoil's lift coefficient
+            by angle of attack and must be either a .csv, .txt, ndarray
+            or callable. The .csv and .txt files must contain no headers
+            and the first column must specify the angle of attack, while
+            the second column must specify the lift coefficient. The
+            ndarray should be as [(x0, y0), (x1, y1), (x2, y2), ...]
+            where x0 is the angle of attack and y0 is the lift coefficient.
+            If callable, it should take an angle of attack as input and
+            return the lift coefficient at that angle of attack.
+            The tuple's second item is the unit of the angle of attack,
+            accepting either "radians" or "degrees".
+        Returns
+        -------
+        cl : Function
+            Function of the angle of attack (Alpha) and the mach number
+            (Mach) expressing the fin's lift coefficient. The inputs
+            are the angle of attack (in radians) and the mach number.
+            The output is the fin's lift coefficient.
+        self : Rocket
+            Object of the Rocket class.
+        """
+        # Retrieves and convert basic geometrical parameters
+        Cr = rootChord
+        s = span
+        radius = self.radius if radius == 0 else radius
+        cantAngleRad = np.radians(cantAngle)
+
+        # Compute auxiliary geometrical parameters
+        d = 2 * radius
+        Aref = np.pi * radius**2 # Reference area for coefficients
+        Af = (np.pi * Cr / 2 * s) / 2 # Fin area
+        AR = 2 * s**2 / Af # Fin aspect ratio
+        Yma = s / (3 * np.pi) * np.sqrt(9 * np.pi**2 - 16) # Span wise coord of mean aero chord
+        rollGeometricalConstant = (
+            Cr
+            * s
+            * (3 * np.pi * s**2 + 32 * radius * s + 12 * np.pi * radius**2)
+            / 48
+        )
+
+        # Center of pressure position relative to CDM (center of dry mass)
+        cpz = distanceToCM + np.sign(distanceToCM) * (0.288 * Cr)
+
+        # Fin–body interference correction parameters
+        tau = (s + radius) / radius
+        liftInterferenceFactor = 1 + 1 / tau
+        rollDampingInterferenceFactor = 1 + (
+            (radius**2)
+            * (
+                2
+                * (radius**2)
+                * np.sqrt(s**2 - radius**2)
+                * np.log(
+                    (2 * s * np.sqrt(s**2 - radius**2) + 2 * s**2) / radius
+                )
+                - 2 * (radius**2) * np.sqrt(s**2 - radius**2) * np.log(2 * s)
+                + 2 * s**3
+                - np.pi * radius * s**2
+                - 2 * (radius**2) * s
+                + np.pi * radius**3
+            )
+        ) / (2 * (s**2) * (s / 3 + np.pi * radius / 4) * (s**2 - radius**2))
+        rollForcingInterferenceFactor = (1 / np.pi**2) * (
+            (np.pi**2 / 4) * ((tau + 1) ** 2 / tau**2)
+            + ((np.pi * (tau**2 + 1) ** 2) / (tau**2 * (tau - 1) ** 2))
+            * np.arcsin((tau**2 - 1) / (tau**2 + 1))
+            - (2 * np.pi * (tau + 1)) / (tau * (tau - 1))
+            + ((tau**2 + 1) ** 2)
+            / (tau**2 * (tau - 1) ** 2)
+            * (np.arcsin((tau**2 - 1) / (tau**2 + 1))) ** 2
+            - (4 * (tau + 1))
+            / (tau * (tau - 1))
+            * np.arcsin((tau**2 - 1) / (tau**2 + 1))
+            + (8 / (tau - 1) ** 2) * np.log((tau**2 + 1) / (2 * tau))
+        )
+
+        # Auxiliary functions
+        # Defines beta parameter
+        def beta(mach):
+            """Defines a parameter that is commonly used in aerodynamic
+            equations. It is commonly used in the Prandtl factor which
+            corrects subsonic force coefficients for compressible flow.
+
+            Parameters
+            ----------
+            mach : int, float
+                Number of mach.
+
+            Returns
+            -------
+            beta : int, float
+                Value that characterizes flow speed based on the mach number.
+            """
+
+            if mach < 0.8:
+                return np.sqrt(1 - mach**2)
+            elif mach < 1.1:
+                return np.sqrt(1 - 0.8**2)
+            else:
+                return np.sqrt(mach**2 - 1)
+
+        # Defines number of fins correction
+        def finNumCorrection(n):
+            """Calculates a corrector factor for the lift coefficient of multiple fins.
+            The specifics  values are documented at:
+            Niskanen, S. (2013). “OpenRocket technical documentation”. In: Development
+            of an Open Source model rocket simulation software.
+
+            Parameters
+            ----------
+            n : int
+                Number of fins.
+
+            Returns
+            -------
+            Corrector factor : int
+                Factor that accounts for the number of fins.
+            """
+            correctorFactor = [2.37, 2.74, 2.99, 3.24]
+            if n >= 5 and n <= 8:
+                return correctorFactor[n - 5]
+            else:
+                return n / 2
+
+        if not airfoil:
+            # Defines clalpha2D as 2*pi for planar fins
+            clalpha2D = Function(lambda mach: 2 * np.pi / beta(mach))
+        else:
+            # Defines clalpha2D as the derivative of the
+            # lift coefficient curve for a specific airfoil
+            airfoilCl = Function(
+                airfoil[0],
+                interpolation="linear",
+            )
+
+            # Differentiating at x = 0 to get cl_alpha
+            clalpha2D_Mach0 = airfoilCl.differentiate(x=1e-3, dx=1e-3)
+
+            # Convert to radians if needed
+            if airfoil[1] == "degrees":
+                clalpha2D_Mach0 *= 180 / np.pi
+
+            # Correcting for compressible flow
+            clalpha2D = Function(lambda mach: clalpha2D_Mach0 / beta(mach))
+        # Diederich's Planform Correlation Parameter
+        FD = 2 * np.pi * AR / (clalpha2D)
+
+        # Lift coefficient derivative for a single fin
+        clalphaSingleFin = Function(
+            lambda mach: (clalpha2D(mach) * FD(mach) * (Af / Aref))
+            / (2 + FD(mach) * np.sqrt(1 + (2 / FD(mach)) ** 2))
+        )
+
+        # Lift coefficient derivative for a number of n fins corrected for Fin-Body interference
+        clalphaMultipleFins = (
+            liftInterferenceFactor * finNumCorrection(n) * clalphaSingleFin
+        )  # Function of mach number
+
+        # Calculates clalpha * alpha
+        cl = Function(
+            lambda alpha, mach: alpha * clalphaMultipleFins(mach),
+            ["Alpha (rad)", "Mach"],
+            "Cl",
+        )
+
+        # Parameters for Roll Moment.
+        # Documented at: https://github.com/Projeto-Jupiter/RocketPy/blob/develop/docs/technical/aerodynamics/Roll_Equations.pdf
+        clfDelta = (
+            rollForcingInterferenceFactor * n * (Yma + radius) * clalphaSingleFin / d
+        )  # Function of mach number
+        cldOmega = (
+            2
+            * rollDampingInterferenceFactor
+            * n
+            * clalphaSingleFin
+            * np.cos(cantAngleRad)
+            * rollGeometricalConstant
+            / (Aref * d**2)
+        )
+        # Function of mach number
+        rollParameters = [clfDelta, cldOmega, cantAngleRad]
+
+        # Store values
+        fin = {
+            "cp": (0, 0, cpz),
+            "cl": cl,
+            "roll parameters": rollParameters,
+            "name": "Fins",
+        }
+        self.aerodynamicSurfaces.append(fin)
+
+        # Refresh static margin calculation
+        self.evaluateStaticMargin()
+
+        # Return self
         return self.aerodynamicSurfaces[-1]
 
     def addParachute(

--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -480,8 +480,8 @@ class Rocket:
         tipChord,
         span,
         distanceToCM,
-        radius=None,
         cantAngle=0,
+        radius=None,
         airfoil=None,
     ):
         """Create a trapezoidal fin set, storing its parameters as part of the
@@ -503,14 +503,14 @@ class Rocket:
             mass, considering positive direction from center of mass to
             nose cone. Consider the center point belonging to the top
             of the fins to calculate distance.
-        radius : int, float, optional
-            Reference radius to calculate lift coefficient. If 0, which
-            is default, use rocket radius. Otherwise, enter the radius
-            of the rocket in the section of the fins, as this impacts
-            its lift coefficient.
         cantAngle : int, float, optional
             Fins cant angle with respect to the rocket centerline. Must
             be given in degrees.
+        radius : int, float, optional
+            Reference radius to calculate lift coefficient. If None, which
+            is default, use rocket radius. Otherwise, enter the radius
+            of the rocket in the section of the fins, as this impacts
+            its lift coefficient.
         airfoil : tuple, optional
             Default is null, in which case fins will be treated as flat plates.
             Otherwise, if tuple, fins will be considered as airfoils. The
@@ -710,8 +710,8 @@ class Rocket:
         rootChord,
         span,
         distanceToCM,
-        radius=0,
         cantAngle=0,
+        radius=None,
         airfoil=None,
     ):
         """Create an elliptical fin set, storing its parameters as part of the
@@ -734,14 +734,14 @@ class Rocket:
             mass, considering positive direction from center of mass to
             nose cone. Consider the center point belonging to the top
             of the fins to calculate distance.
-        radius : int, float, optional
-            Reference radius to calculate lift coefficient. If 0, which
-            is default, use rocket radius. Otherwise, enter the radius
-            of the rocket in the section of the fins, as this impacts
-            its lift coefficient.
         cantAngle : int, float, optional
             Fins cant angle with respect to the rocket centerline. Must
             be given in degrees.
+        radius : int, float, optional
+            Reference radius to calculate lift coefficient. If None, which
+            is default, use rocket radius. Otherwise, enter the radius
+            of the rocket in the section of the fins, as this impacts
+            its lift coefficient.
         airfoil : tuple, optional
             Default is null, in which case fins will be treated as flat plates.
             Otherwise, if tuple, fins will be considered as airfoils. The
@@ -769,7 +769,7 @@ class Rocket:
         # Retrieves and convert basic geometrical parameters
         Cr = rootChord
         s = span
-        radius = self.radius if radius == 0 else radius
+        radius = self.radius if radius is None else radius
         cantAngleRad = np.radians(cantAngle)
 
         # Compute auxiliary geometrical parameters

--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -467,7 +467,7 @@ class Rocket:
         by version 2.0.0. Use Rocket.addTrapezoidalFins instead. It keeps the
         same arguments and signature."""
         warnings.warn(
-            "This method is set to be deprecated in version 1.0.0 and fully"
+            "This method is set to be deprecated in version 1.0.0 and fully "
             "removed by version 2.0.0. Use Rocket.addTrapezoidalFins instead",
             PendingDeprecationWarning
         )

--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -461,7 +461,7 @@ class Rocket:
         # Return self
         return self.aerodynamicSurfaces[-1]
 
-    def addFins(self,*args, **kwargs):
+    def addFins(self, *args, **kwargs):
         """See Rocket.addTrapezoidalFins for documentation.
         This method is set to be deprecated in version 1.0.0 and fully removed
         by version 2.0.0. Use Rocket.addTrapezoidalFins instead. It keeps the
@@ -469,7 +469,7 @@ class Rocket:
         warnings.warn(
             "This method is set to be deprecated in version 1.0.0 and fully "
             "removed by version 2.0.0. Use Rocket.addTrapezoidalFins instead",
-            PendingDeprecationWarning
+            PendingDeprecationWarning,
         )
         self.addTrapezoidalFins(*args, **kwargs)
 
@@ -482,7 +482,7 @@ class Rocket:
         distanceToCM,
         radius=None,
         cantAngle=0,
-        airfoil=None
+        airfoil=None,
     ):
         """Create a trapezoidal fin set, storing its parameters as part of the
         aerodynamicSurfaces list. Its parameters are the axial position
@@ -545,10 +545,10 @@ class Rocket:
         d = 2 * radius
         Aref = np.pi * radius**2
         Yr = Cr + Ct
-        Af = Yr * s / 2 # Fin area
-        AR = 2 * s**2 / Af # Fin aspect ratio
+        Af = Yr * s / 2  # Fin area
+        AR = 2 * s**2 / Af  # Fin aspect ratio
         gamac = np.arctan((Cr - Ct) / (2 * s))  # Mid chord angle
-        Yma = (s / 3) * (Cr + 2 * Ct) / Yr # Span wise coord of mean aero chord
+        Yma = (s / 3) * (Cr + 2 * Ct) / Yr  # Span wise coord of mean aero chord
         rollGeometricalConstant = (
             (Cr + 3 * Ct) * s**3
             + 4 * (Cr + 2 * Ct) * radius * s**2
@@ -633,7 +633,7 @@ class Rocket:
 
             # Correcting for compressible flow
             clalpha2D = Function(lambda mach: clalpha2D_Mach0 / beta(mach))
-    
+
         # Diederich's Planform Correlation Parameter
         FD = 2 * np.pi * AR / (clalpha2D * np.cos(gamac))
 
@@ -660,8 +660,7 @@ class Rocket:
         rollDampingInterferenceFactor = 1 + (
             ((tau - λ) / (tau)) - ((1 - λ) / (tau - 1)) * np.log(tau)
         ) / (
-            ((tau + 1) * (tau - λ)) / (2)
-            - ((1 - λ) * (tau**3 - 1)) / (3 * (tau - 1))
+            ((tau + 1) * (tau - λ)) / (2) - ((1 - λ) * (tau**3 - 1)) / (3 * (tau - 1))
         )
         rollForcingInterferenceFactor = (1 / np.pi**2) * (
             (np.pi**2 / 4) * ((tau + 1) ** 2 / tau**2)
@@ -687,7 +686,7 @@ class Rocket:
             * np.cos(cantAngleRad)
             * rollGeometricalConstant
             / (Aref * d**2)
-        ) # Function of mach number
+        )  # Function of mach number
         rollParameters = [clfDelta, cldOmega, cantAngleRad]
 
         # Store values
@@ -704,7 +703,7 @@ class Rocket:
 
         # Return the created aerodynamic surface
         return self.aerodynamicSurfaces[-1]
-    
+
     def addEllipticalFins(
         self,
         n,
@@ -775,10 +774,12 @@ class Rocket:
 
         # Compute auxiliary geometrical parameters
         d = 2 * radius
-        Aref = np.pi * radius**2 # Reference area for coefficients
-        Af = (np.pi * Cr / 2 * s) / 2 # Fin area
-        AR = 2 * s**2 / Af # Fin aspect ratio
-        Yma = s / (3 * np.pi) * np.sqrt(9 * np.pi**2 - 16) # Span wise coord of mean aero chord
+        Aref = np.pi * radius**2  # Reference area for coefficients
+        Af = (np.pi * Cr / 2 * s) / 2  # Fin area
+        AR = 2 * s**2 / Af  # Fin aspect ratio
+        Yma = (
+            s / (3 * np.pi) * np.sqrt(9 * np.pi**2 - 16)
+        )  # Span wise coord of mean aero chord
         rollGeometricalConstant = (
             Cr
             * s
@@ -798,9 +799,7 @@ class Rocket:
                 2
                 * (radius**2)
                 * np.sqrt(s**2 - radius**2)
-                * np.log(
-                    (2 * s * np.sqrt(s**2 - radius**2) + 2 * s**2) / radius
-                )
+                * np.log((2 * s * np.sqrt(s**2 - radius**2) + 2 * s**2) / radius)
                 - 2 * (radius**2) * np.sqrt(s**2 - radius**2) * np.log(2 * s)
                 + 2 * s**3
                 - np.pi * radius * s**2


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Code base additions (bugfix, features)
- [x] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base maintenance (refactoring, formatting, renaming):

  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [ ] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The proposed implementation of Rocket.addFins (#172 ) will cause breaking changes.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The new proposed implementation creates two methods: `Rocket.addTrapezoidalFins` and `Rocket.addEllipticalFins` to avoid breaking changes. Furthermore, it marks `Rocket.addFins` as a future deprecation to be removed in version 2.0.0 (to be discussed).

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
Work to fix notebooks and docs that mention `addFins` must be worked on to reflect theses changes.